### PR TITLE
Publish wheels for Python 3.12+ using abi3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     runs-on: ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - uses: dtolnay/rust-toolchain@stable
@@ -44,10 +44,10 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
@@ -56,7 +56,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.runs-on }}
+        name: sdist
         path: target/wheels
 
   pack-linux:
@@ -65,24 +65,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         target: [ x86_64, i686 ]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
         manylinux: auto
-        args: -i ${{ matrix.python-version }} --release
+        args: -i 3.8 --release
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.runs-on }}
+        name: wheels-linux-${{ matrix.target }}
         path: target/wheels
 
   pack-windows:
@@ -91,13 +90,12 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         target: [ x64, x86 ]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
         architecture: ${{ matrix.target }}
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
@@ -105,36 +103,32 @@ jobs:
       with:
         target: ${{ matrix.target }}
         manylinux: auto
-        args: -i ${{ matrix.python-version }} --release
+        args: -i 3.8 --release
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.runs-on }}
+        name: wheels-windows-${{ matrix.target }}
         path: target/wheels
 
   pack-macos:
     needs: [ test ]
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.8'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
       with:
-        target: ${{ matrix.target }}
         manylinux: auto
-        args: -i ${{ matrix.python-version }} --release --universal2
+        args: -i 3.8 --release --universal2
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.runs-on }}
+        name: wheels-macos-universal2
         path: target/wheels
 
   release:
@@ -143,6 +137,9 @@ jobs:
     needs: [ pack-sdist, pack-linux, pack-windows, pack-macos ]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
       - uses: actions/download-artifact@v4
         with:
           pattern: wheels-*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         command: sdist
     - name: Upload sdist
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sdist
         path: target/wheels
@@ -76,7 +76,7 @@ jobs:
         manylinux: auto
         args: -i 3.10 --release
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheels-linux-${{ matrix.target }}
         path: target/wheels
@@ -99,10 +99,9 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        manylinux: auto
         args: -i 3.10 --release
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheels-windows-${{ matrix.target }}
         path: target/wheels
@@ -120,10 +119,9 @@ jobs:
     - name: Build package
       uses: PyO3/maturin-action@v1
       with:
-        manylinux: auto
-        args: -i 3.10 --release --universal2
+        args: -i 3.10 --release --target universal2-apple-darwin
     - name: Upload wheels
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: wheels-macos-universal2
         path: target/wheels
@@ -137,7 +135,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
       - name: Install uv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,9 +45,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-      with:
-        python-version: '3.14'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -133,6 +133,9 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [ pack-sdist, pack-linux, pack-windows, pack-macos ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -142,9 +145,7 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
       - name: Publish to PyPI
-        uses: messense/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        uses: PyO3/maturin-action@v1
         with:
           command: upload
           args: --skip-existing *

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,9 +136,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@v8
-        with:
-          pattern: wheels-*
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Publish to PyPI
-        run: uv publish --trusted-publishing always wheels-*/*
+        run: uv publish --trusted-publishing always wheels-*/* sdist/*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,14 +139,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: sdist
-          path: dist
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
           pattern: wheels-*
-          merge-multiple: true
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Publish to PyPI
-        run: uv publish --trusted-publishing always
+        run: uv publish --trusted-publishing always wheels-*/*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         runs-on: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v6
@@ -67,14 +67,14 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
         manylinux: auto
-        args: -i 3.8 --release
+        args: -i 3.10 --release
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.10'
         architecture: ${{ matrix.target }}
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
@@ -100,7 +100,7 @@ jobs:
       with:
         target: ${{ matrix.target }}
         manylinux: auto
-        args: -i 3.8 --release
+        args: -i 3.10 --release
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
@@ -115,13 +115,13 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - uses: dtolnay/rust-toolchain@stable
     - name: Build package
       uses: PyO3/maturin-action@v1
       with:
         manylinux: auto
-        args: -i 3.8 --release --universal2
+        args: -i 3.10 --release --universal2
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         command: sdist
-    - name: Upload wheels
+    - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
         name: sdist

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -140,12 +140,13 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: sdist
+          path: dist
       - uses: actions/download-artifact@v4
         with:
+          path: dist
           pattern: wheels-*
           merge-multiple: true
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        with:
-          command: upload
-          args: --skip-existing *
+        run: uv publish --trusted-publishing always

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 hashbrown = "0.13.2" # MIT or Apache-2.0
 ouroboros = "0.15.6" # MIT or Apache-2.0
-pyo3 = { version = "0.18.2", features = ["extension-module"] } # Apache-2.0
+pyo3 = { version = "0.18.2", features = ["extension-module", "abi3-py38"] } # Apache-2.0
 vibrato_rust = { package = "vibrato", version = "0.5.0", default-features = false } # MIT or Apache-2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 [dependencies]
 hashbrown = "0.13.2" # MIT or Apache-2.0
 ouroboros = "0.15.6" # MIT or Apache-2.0
-pyo3 = { version = "0.18.2", features = ["extension-module", "abi3-py38"] } # Apache-2.0
+pyo3 = { version = "0.18.2", features = ["extension-module", "abi3-py310"] } # Apache-2.0
 vibrato_rust = { package = "vibrato", version = "0.5.0", default-features = false } # MIT or Apache-2.0

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check the version number as shown below to use compatible models:
 ```python
 >>> import vibrato
 >>> vibrato.VIBRATO_VERSION
-'0.5.1'
+'0.5.2'
 
 ```
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -11,7 +11,7 @@ You can check the version number as shown below to use compatible models:
 
    >>> import vibrato
    >>> vibrato.VIBRATO_VERSION
-   '0.5.1'
+   '0.5.2'
 
 Examples:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]
 name = "vibrato"
+dynamic = ["version"]
+requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,4 @@ build-backend = "maturin"
 [project]
 name = "vibrato"
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,10 @@ struct TokenIterator {
 
 #[pymethods]
 impl TokenIterator {
+    fn __iter__(self_: PyRef<Self>) -> Py<Self> {
+        self_.into()
+    }
+
     fn __next__(&mut self, py: Python) -> Option<Token> {
         if self.index < self.len {
             let index = self.index;


### PR DESCRIPTION
## Summary

This PR updates packaging and CI so vibrato can publish wheels usable on Python 3.12, 3.13, and 3.14.

It switches the extension module to PyO3 abi3 with a minimum supported Python version of 3.10, allowing one cp310-abi3 wheel to work across supported CPython versions instead of building a separate wheel for each minor version.

## Changes

- enable `pyo3` `abi3-py310`
- set `requires-python = ">=3.10"`
- add `dynamic = ["version"]` for `maturin`
- update the `maturin` build requirement to `>=1,<2`
- test on Python 3.10 through 3.14
- build release wheels once per platform/architecture
- remove `setup-python` from the `sdist` job
- update GitHub Actions to `checkout@v6` and `setup-python@v6`
- switch publishing from `maturin upload` to `uv publish` with Trusted Publishing
- fix `TokenIterator` to fully implement the Python iterator protocol
- update doctest version examples from `0.5.1` to `0.5.2`

## Requests

- https://github.com/daac-tools/python-vibrato/issues/13