### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,17 @@ on:
       - 'v*.*.*'
 
 jobs:
+  check-release-version:
+    if: "startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Verify tag matches Cargo.toml version
+      run: |
+        TAG="${GITHUB_REF_NAME#v}"
+        VERSION="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n1)"
+        test "$TAG" = "$VERSION"
+
   test:
     strategy:
       matrix:
@@ -40,7 +51,7 @@ jobs:
         python -m doctest docs/source/examples.rst
 
   pack-sdist:
-    needs: [ test ]
+    needs: [ check-release-version, test ]
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +68,7 @@ jobs:
         path: target/wheels
 
   pack-linux:
-    needs: [ test ]
+    needs: [ check-release-version, test ]
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     strategy:
@@ -82,7 +93,7 @@ jobs:
         path: target/wheels
 
   pack-windows:
-    needs: [ test ]
+    needs: [ check-release-version, test ]
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: windows-latest
     strategy:
@@ -107,7 +118,7 @@ jobs:
         path: target/wheels
 
   pack-macos:
-    needs: [ test ]
+    needs: [ check-release-version, test ]
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: macos-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-vibrato"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
This PR uploads python-vibrato version 0.2.2.

Sorry, I accidentally issued the 0.2.1 tag without updating the version to 0.2.1. As a result, [the artifact release failed](https://github.com/daac-tools/python-vibrato/actions/runs/26675498173/job/78626938896). Because of this, we must re-upload the artifacts as 0.2.2, and it seems that the following actions are needed:

1. Clearly state in Release 0.2.1 that it was an erroneous release and that users should use 0.2.2 instead.
2. Yank 0.2.0, where files such as `vibrato-0.2.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl` were published by mistake. (see https://docs.pypi.org/project-management/yanking/)

Also, as a preventive measure, I added a version consistency check to CI.
