### PR TITLE
Update package metadata and Read the Docs build configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,14 +2,17 @@ version: 2
 
 sphinx:
   builder: html
+  configuration: docs/source/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
-    rust: "1.64"
+    python: latest
+    rust: latest
 
 python:
   install:
     - method: pip
       path: .
+      extra_requirements:
+        - docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-vibrato"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,9 @@ classifiers = [
   "Topic :: Software Development :: Libraries",
   "Topic :: Text Processing",
 ]
+
+[project.optional-dependencies]
+docs = [
+  "sphinx",
+  "sphinx-rtd-theme",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,12 @@ build-backend = "maturin"
 name = "vibrato"
 dynamic = ["version"]
 requires-python = ">=3.10"
+description = "🎤 vibrato: VIterbi-Based acceleRAted TOkenizer"
+readme = "README.md"
+classifiers = [
+  "License :: OSI Approved :: Apache Software License",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Rust",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Text Processing",
+]


### PR DESCRIPTION
This PR updates:

- the package metadata for pypi release, and
- Read the Docs configuration so the documentation build can install and build the project correctly,

while updating the version to 0.2.3.
